### PR TITLE
doc: fix the result of examples

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -74,7 +74,7 @@ The main export is a function that takes two integers: the `min` value and `max`
 
 ```js
 const source = toRegexRange('15', '95');
-//=> 1[5-9]|[2-8][0-9]|9[0-5]
+//=> (?:1[5-9]|[2-8][0-9]|9[0-5])
 
 const regex = new RegExp(`^${source}$`);
 console.log(regex.test('14')); //=> false
@@ -95,7 +95,7 @@ Wrap the returned value in parentheses when there is more than one regex conditi
 
 ```js
 console.log(toRegexRange('-10', '10'));
-//=> -[1-9]|-?10|[0-9]
+//=> (?:-[1-9]|-?10|[0-9])
 
 console.log(toRegexRange('-10', '10', { capture: true }));
 //=> (-[1-9]|-?10|[0-9])
@@ -111,10 +111,10 @@ Use the regex shorthand for `[0-9]`:
 
 ```js
 console.log(toRegexRange('0', '999999'));
-//=> [0-9]|[1-9][0-9]{1,5}
+//=> (?:[0-9]|[1-9][0-9]{1,5})
 
 console.log(toRegexRange('0', '999999', { shorthand: true }));
-//=> \d|[1-9]\d{1,5}
+//=> (?:\d|[1-9]\d{1,5})
 ```
 
 ### options.relaxZeros
@@ -167,7 +167,7 @@ Is effectively flipped to:
 
 ```js
 toRegexRange('29', '51');
-//=> 29|[3-4][0-9]|5[0-1]
+//=> (?:29|[3-4][0-9]|5[0-1])
 ```
 
 **Steps / increments**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# to-regex-range [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=W8YFZ425KND68) [![NPM version](https://img.shields.io/npm/v/to-regex-range.svg?style=flat)](https://www.npmjs.com/package/to-regex-range) [![NPM monthly downloads](https://img.shields.io/npm/dm/to-regex-range.svg?style=flat)](https://npmjs.org/package/to-regex-range) [![NPM total downloads](https://img.shields.io/npm/dt/to-regex-range.svg?style=flat)](https://npmjs.org/package/to-regex-range) [![Linux Build Status](https://img.shields.io/travis/micromatch/to-regex-range.svg?style=flat&label=Travis)](https://travis-ci.org/micromatch/to-regex-range)
+# to-regex-range [![NPM version](https://img.shields.io/npm/v/to-regex-range.svg?style=flat)](https://www.npmjs.com/package/to-regex-range) [![NPM monthly downloads](https://img.shields.io/npm/dm/to-regex-range.svg?style=flat)](https://npmjs.org/package/to-regex-range) [![NPM total downloads](https://img.shields.io/npm/dt/to-regex-range.svg?style=flat)](https://npmjs.org/package/to-regex-range) [![Linux Build Status](https://img.shields.io/travis/micromatch/to-regex-range.svg?style=flat&label=Travis)](https://travis-ci.org/micromatch/to-regex-range)
 
 > Pass two numbers, get a regex-compatible source string for matching ranges. Validated against more than 2.78 million test assertions.
 
@@ -59,7 +59,7 @@ If you're interested in learning more about [character classes](http://www.regul
 
 ### Heavily tested
 
-As of April 07, 2019, this library runs [>1m test assertions](./test/test.js) against generated regex-ranges to provide brute-force verification that results are correct.
+As of October 26, 2020, this library runs [>1m test assertions](./test/test.js) against generated regex-ranges to provide brute-force verification that results are correct.
 
 Tests run in ~280ms on my MacBook Pro, 2.5 GHz Intel Core i7.
 
@@ -87,7 +87,7 @@ The main export is a function that takes two integers: the `min` value and `max`
 
 ```js
 const source = toRegexRange('15', '95');
-//=> 1[5-9]|[2-8][0-9]|9[0-5]
+//=> (?:1[5-9]|[2-8][0-9]|9[0-5])
 
 const regex = new RegExp(`^${source}$`);
 console.log(regex.test('14')); //=> false
@@ -108,7 +108,7 @@ Wrap the returned value in parentheses when there is more than one regex conditi
 
 ```js
 console.log(toRegexRange('-10', '10'));
-//=> -[1-9]|-?10|[0-9]
+//=> (?:-[1-9]|-?10|[0-9])
 
 console.log(toRegexRange('-10', '10', { capture: true }));
 //=> (-[1-9]|-?10|[0-9])
@@ -124,10 +124,10 @@ Use the regex shorthand for `[0-9]`:
 
 ```js
 console.log(toRegexRange('0', '999999'));
-//=> [0-9]|[1-9][0-9]{1,5}
+//=> (?:[0-9]|[1-9][0-9]{1,5})
 
 console.log(toRegexRange('0', '999999', { shorthand: true }));
-//=> \d|[1-9]\d{1,5}
+//=> (?:\d|[1-9]\d{1,5})
 ```
 
 ### options.relaxZeros
@@ -164,32 +164,32 @@ console.log(regex.test('0010')); //=> true
 
 ## Examples
 
-| **Range**                   | **Result**                                                                      | **Compile time** |
-| ---                         | ---                                                                             | ---              |
-| `toRegexRange(-10, 10)`     | `-[1-9]\|-?10\|[0-9]`                                                           | _132μs_          |
-| `toRegexRange(-100, -10)`   | `-1[0-9]\|-[2-9][0-9]\|-100`                                                    | _50μs_           |
-| `toRegexRange(-100, 100)`   | `-[1-9]\|-?[1-9][0-9]\|-?100\|[0-9]`                                            | _42μs_           |
-| `toRegexRange(001, 100)`    | `0{0,2}[1-9]\|0?[1-9][0-9]\|100`                                                | _109μs_          |
-| `toRegexRange(001, 555)`    | `0{0,2}[1-9]\|0?[1-9][0-9]\|[1-4][0-9]{2}\|5[0-4][0-9]\|55[0-5]`                | _51μs_           |
-| `toRegexRange(0010, 1000)`  | `0{0,2}1[0-9]\|0{0,2}[2-9][0-9]\|0?[1-9][0-9]{2}\|1000`                         | _31μs_           |
-| `toRegexRange(1, 50)`       | `[1-9]\|[1-4][0-9]\|50`                                                         | _24μs_           |
-| `toRegexRange(1, 55)`       | `[1-9]\|[1-4][0-9]\|5[0-5]`                                                     | _23μs_           |
-| `toRegexRange(1, 555)`      | `[1-9]\|[1-9][0-9]\|[1-4][0-9]{2}\|5[0-4][0-9]\|55[0-5]`                        | _30μs_           |
-| `toRegexRange(1, 5555)`     | `[1-9]\|[1-9][0-9]{1,2}\|[1-4][0-9]{3}\|5[0-4][0-9]{2}\|55[0-4][0-9]\|555[0-5]` | _43μs_           |
-| `toRegexRange(111, 555)`    | `11[1-9]\|1[2-9][0-9]\|[2-4][0-9]{2}\|5[0-4][0-9]\|55[0-5]`                     | _38μs_           |
-| `toRegexRange(29, 51)`      | `29\|[34][0-9]\|5[01]`                                                          | _24μs_           |
-| `toRegexRange(31, 877)`     | `3[1-9]\|[4-9][0-9]\|[1-7][0-9]{2}\|8[0-6][0-9]\|87[0-7]`                       | _32μs_           |
-| `toRegexRange(5, 5)`        | `5`                                                                             | _8μs_            |
-| `toRegexRange(5, 6)`        | `5\|6`                                                                          | _11μs_           |
-| `toRegexRange(1, 2)`        | `1\|2`                                                                          | _6μs_            |
-| `toRegexRange(1, 5)`        | `[1-5]`                                                                         | _15μs_           |
-| `toRegexRange(1, 10)`       | `[1-9]\|10`                                                                     | _22μs_           |
-| `toRegexRange(1, 100)`      | `[1-9]\|[1-9][0-9]\|100`                                                        | _25μs_           |
-| `toRegexRange(1, 1000)`     | `[1-9]\|[1-9][0-9]{1,2}\|1000`                                                  | _31μs_           |
-| `toRegexRange(1, 10000)`    | `[1-9]\|[1-9][0-9]{1,3}\|10000`                                                 | _34μs_           |
-| `toRegexRange(1, 100000)`   | `[1-9]\|[1-9][0-9]{1,4}\|100000`                                                | _36μs_           |
-| `toRegexRange(1, 1000000)`  | `[1-9]\|[1-9][0-9]{1,5}\|1000000`                                               | _42μs_           |
-| `toRegexRange(1, 10000000)` | `[1-9]\|[1-9][0-9]{1,6}\|10000000`                                              | _42μs_           |
+| **Range**                   | **Result**                                                                          | **Compile time** |
+| ---                         | ---                                                                                 | ---              |
+| `toRegexRange(-10, 10)`     | `(?:-[1-9]\|-?10\|[0-9])`                                                           | _123μs_          |
+| `toRegexRange(-100, -10)`   | `(?:-1[0-9]\|-[2-9][0-9]\|-100)`                                                    | _88μs_           |
+| `toRegexRange(-100, 100)`   | `(?:-[1-9]\|-?[1-9][0-9]\|-?100\|[0-9])`                                            | _77μs_           |
+| `toRegexRange(001, 100)`    | `(?:0{0,2}[1-9]\|0?[1-9][0-9]\|100)`                                                | _129μs_          |
+| `toRegexRange(001, 555)`    | `(?:0{0,2}[1-9]\|0?[1-9][0-9]\|[1-4][0-9]{2}\|5[0-4][0-9]\|55[0-5])`                | _54μs_           |
+| `toRegexRange(0010, 1000)`  | `(?:0{0,2}1[0-9]\|0{0,2}[2-9][0-9]\|0?[1-9][0-9]{2}\|1000)`                         | _45μs_           |
+| `toRegexRange(1, 50)`       | `(?:[1-9]\|[1-4][0-9]\|50)`                                                         | _29μs_           |
+| `toRegexRange(1, 55)`       | `(?:[1-9]\|[1-4][0-9]\|5[0-5])`                                                     | _28μs_           |
+| `toRegexRange(1, 555)`      | `(?:[1-9]\|[1-9][0-9]\|[1-4][0-9]{2}\|5[0-4][0-9]\|55[0-5])`                        | _32μs_           |
+| `toRegexRange(1, 5555)`     | `(?:[1-9]\|[1-9][0-9]{1,2}\|[1-4][0-9]{3}\|5[0-4][0-9]{2}\|55[0-4][0-9]\|555[0-5])` | _49μs_           |
+| `toRegexRange(111, 555)`    | `(?:11[1-9]\|1[2-9][0-9]\|[2-4][0-9]{2}\|5[0-4][0-9]\|55[0-5])`                     | _35μs_           |
+| `toRegexRange(29, 51)`      | `(?:29\|[34][0-9]\|5[01])`                                                          | _24μs_           |
+| `toRegexRange(31, 877)`     | `(?:3[1-9]\|[4-9][0-9]\|[1-7][0-9]{2}\|8[0-6][0-9]\|87[0-7])`                       | _35μs_           |
+| `toRegexRange(5, 5)`        | `5`                                                                                 | _9μs_            |
+| `toRegexRange(5, 6)`        | `(?:5\|6)`                                                                          | _10μs_           |
+| `toRegexRange(1, 2)`        | `(?:1\|2)`                                                                          | _6μs_            |
+| `toRegexRange(1, 5)`        | `[1-5]`                                                                             | _19μs_           |
+| `toRegexRange(1, 10)`       | `(?:[1-9]\|10)`                                                                     | _21μs_           |
+| `toRegexRange(1, 100)`      | `(?:[1-9]\|[1-9][0-9]\|100)`                                                        | _25μs_           |
+| `toRegexRange(1, 1000)`     | `(?:[1-9]\|[1-9][0-9]{1,2}\|1000)`                                                  | _24μs_           |
+| `toRegexRange(1, 10000)`    | `(?:[1-9]\|[1-9][0-9]{1,3}\|10000)`                                                 | _32μs_           |
+| `toRegexRange(1, 100000)`   | `(?:[1-9]\|[1-9][0-9]{1,4}\|100000)`                                                | _33μs_           |
+| `toRegexRange(1, 1000000)`  | `(?:[1-9]\|[1-9][0-9]{1,5}\|1000000)`                                               | _34μs_           |
+| `toRegexRange(1, 10000000)` | `(?:[1-9]\|[1-9][0-9]{1,6}\|10000000)`                                              | _38μs_           |
 
 ## Heads up!
 
@@ -205,7 +205,7 @@ Is effectively flipped to:
 
 ```js
 toRegexRange('29', '51');
-//=> 29|[3-4][0-9]|5[0-1]
+//=> (?:29|[3-4][0-9]|5[0-1])
 ```
 
 **Steps / increments**
@@ -213,6 +213,10 @@ toRegexRange('29', '51');
 This library does not support steps (increments). A pr to add support would be welcome.
 
 ## History
+
+### v5.0.0 - 2019-04-07
+
+Optimizations. Updated code to use newer ES features.
 
 ### v2.0.0 - 2017-04-21
 
@@ -269,7 +273,7 @@ You might also be interested in these projects:
 
 * [expand-range](https://www.npmjs.com/package/expand-range): Fast, bash-like range expansion. Expand a range of numbers or letters, uppercase or lowercase. Used… [more](https://github.com/jonschlinkert/expand-range) | [homepage](https://github.com/jonschlinkert/expand-range "Fast, bash-like range expansion. Expand a range of numbers or letters, uppercase or lowercase. Used by micromatch.")
 * [fill-range](https://www.npmjs.com/package/fill-range): Fill in a range of numbers or letters, optionally passing an increment or `step` to… [more](https://github.com/jonschlinkert/fill-range) | [homepage](https://github.com/jonschlinkert/fill-range "Fill in a range of numbers or letters, optionally passing an increment or `step` to use, or create a regex-compatible range with `options.toRegex`")
-* [micromatch](https://www.npmjs.com/package/micromatch): Glob matching for javascript/node.js. A drop-in replacement and faster alternative to minimatch and multimatch. | [homepage](https://github.com/micromatch/micromatch "Glob matching for javascript/node.js. A drop-in replacement and faster alternative to minimatch and multimatch.")
+* [micromatch](https://www.npmjs.com/package/micromatch): Glob matching for javascript/node.js. A replacement and faster alternative to minimatch and multimatch. | [homepage](https://github.com/micromatch/micromatch "Glob matching for javascript/node.js. A replacement and faster alternative to minimatch and multimatch.")
 * [repeat-element](https://www.npmjs.com/package/repeat-element): Create an array by repeating the given value n times. | [homepage](https://github.com/jonschlinkert/repeat-element "Create an array by repeating the given value n times.")
 * [repeat-string](https://www.npmjs.com/package/repeat-string): Repeat the given string n times. Fastest implementation for repeating a string. | [homepage](https://github.com/jonschlinkert/repeat-string "Repeat the given string n times. Fastest implementation for repeating a string.")
 
@@ -277,7 +281,7 @@ You might also be interested in these projects:
 
 | **Commits** | **Contributor** |  
 | --- | --- |  
-| 63 | [jonschlinkert](https://github.com/jonschlinkert) |  
+| 70 | [jonschlinkert](https://github.com/jonschlinkert) |  
 | 3  | [doowb](https://github.com/doowb) |  
 | 2  | [realityking](https://github.com/realityking) |  
 
@@ -289,17 +293,11 @@ You might also be interested in these projects:
 * [Twitter Profile](https://twitter.com/jonschlinkert)
 * [LinkedIn Profile](https://linkedin.com/in/jonschlinkert)
 
-Please consider supporting me on Patreon, or [start your own Patreon page](https://patreon.com/invite/bxpbvm)!
-
-<a href="https://www.patreon.com/jonschlinkert">
-<img src="https://c5.patreon.com/external/logo/become_a_patron_button@2x.png" height="50">
-</a>
-
 ### License
 
-Copyright © 2019, [Jon Schlinkert](https://github.com/jonschlinkert).
+Copyright © 2020, [Jon Schlinkert](https://github.com/jonschlinkert).
 Released under the [MIT License](LICENSE).
 
 ***
 
-_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.8.0, on April 07, 2019._
+_This file was generated by [verb-generate-readme](https://github.com/verbose/verb-generate-readme), v0.8.0, on October 26, 2020._

--- a/examples.js
+++ b/examples.js
@@ -16,7 +16,7 @@ const toRange = (min, max) => {
   return [
     '',
     `\`toRegexRange(${min}, ${max})\``,
-    `\`${toRegexRange(min, max, { wrap: false }).split('|').join('\\|')}\``,
+    `\`${toRegexRange(min, max).split('|').join('\\|')}\``,
     `_${time.end(key)}_`,
     ''
   ];

--- a/package.json
+++ b/package.json
@@ -72,8 +72,12 @@
     },
     "helpers": {
       "examples": {
-        "displayName": "examples"
-      }
+        "displayName": "examples",
+        "options": {
+          "displayName": "examples"
+        }
+      },
+      "gh": {}
     },
     "related": {
       "list": [
@@ -83,6 +87,12 @@
         "repeat-element",
         "repeat-string"
       ]
-    }
+    },
+    "reflinks": [
+      "0-5",
+      "0-9",
+      "1-5",
+      "1-9"
+    ]
   }
 }


### PR DESCRIPTION
Thank you for this awesome project. I found that some examples' result of the document are outdated and updated them.

I added `(?:` `)` wrap to the results (This is the default behavior) and changed the `example.js` script to using default options.