### PR TITLE
fix: replace is-number dep with a one-liner

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const isNumber = require('is-number');
+const isNumber = (v) => typeof v === "number" || (typeof v === "string" && Number.isFinite(+v))
 
 const toRegexRange = (min, max, options) => {
   if (isNumber(min) === false) {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const isNumber = (v) => typeof v === "number" || (typeof v === "string" && Number.isFinite(+v) && v.trim() !== "");
+const isNumber = (v) => (typeof v === "number" && v - v === 0) || (typeof v === "string" && Number.isFinite(+v) && v.trim() !== "");
 
 const toRegexRange = (min, max, options) => {
   if (isNumber(min) === false) {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const isNumber = (v) => typeof v === "number" || (typeof v === "string" && Number.isFinite(+v))
+const isNumber = (v) => typeof v === "number" || (typeof v === "string" && Number.isFinite(+v) && v.trim() !== "");
 
 const toRegexRange = (min, max, options) => {
   if (isNumber(min) === false) {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
   "scripts": {
     "test": "mocha"
   },
-  "dependencies": {
-    "is-number": "^7.0.0"
-  },
   "devDependencies": {
     "fill-range": "^6.0.0",
     "gulp-format-md": "^2.0.0",


### PR DESCRIPTION
This PR replaces `is-number` package with a one-liner with identical code. It passes all the tests (`npm run test`).

This tiny change saves 440GB weekly traffic:

```
Package size report
===================

Package info for "to-regex-range@5.0.1": 33 kB
  Released: 2019-04-07 06:04:37.03 +0000 UTC (277w2d ago)
  Downloads last week: 43,837,006
  Estimated traffic last week: 1.5 TB

Removed dependencies:
  - is-number@7.0.0: 10 kB (30.06%)
    Downloads last week: 43,875,245
    Downloads last week from "to-regex-range@5.0.1": 43,837,006 (99.91%)
    Estimated traffic last week: 440 GB
    Estimated traffic from "to-regex-range@5.0.1": 440 GB (99.91%)

Estimated package size: 33 kB → 23 kB (69.94%)
Estimated traffic over a week: 1.5 TB → 1.0 TB (440 GB saved)
```