### PR TITLE
Fix typo in .verb.md

### DIFF
--- a/.verb.md
+++ b/.verb.md
@@ -191,7 +191,7 @@ Adds support for zero-padding!
 
 **Optimizations**
 
-Repeating ranges are now grouped using quantifiers. rocessing time is roughly the same, but the generated regex is much smaller, which should result in faster matching.
+Repeating ranges are now grouped using quantifiers. Processing time is roughly the same, but the generated regex is much smaller, which should result in faster matching.
 
 ## Attribution
 


### PR DESCRIPTION
Change "rocessing" back into "Processing" in the History section of `.verb.md` (spelling was changed to the incorrect version in [4dc2a4f](https://github.com/micromatch/to-regex-range/commit/4dc2a4f237d8c9789837828663ef9937d657b72a))

not exactly the most groundbreaking PR but it was bugging me