### PR TITLE
Fix CRITICAL MOCHA security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "fill-range": "^6.0.0",
     "gulp-format-md": "^2.0.0",
-    "mocha": "^6.0.2",
+    "mocha": "^11.0.1",
     "text-table": "^0.2.0",
     "time-diff": "^0.3.1"
   },


### PR DESCRIPTION
This PR updates mocha in order to fix *3* critical level vulnerabilities. You can view them using `npm audit` on `master`.